### PR TITLE
Update SimpleItemTouchHelperCallback.java

### DIFF
--- a/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/helper/SimpleItemTouchHelperCallback.java
+++ b/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/helper/SimpleItemTouchHelperCallback.java
@@ -72,8 +72,8 @@ public class SimpleItemTouchHelperCallback extends ItemTouchHelper.Callback {
         }
 
         // Notify the adapter of the move
-        mAdapter.onItemMove(source.getAdapterPosition(), target.getAdapterPosition());
-        return true;
+        return mAdapter.onItemMove(source.getAdapterPosition(), target.getAdapterPosition());
+        //return true;
     }
 
     @Override


### PR DESCRIPTION
onMove() should be fixed, since sometimes adapter can return that movement is prohibited and return false
