### PR TITLE
fix(Grid Mode):keep the data in adapter synchronized with the view when moving items in grid mode

### DIFF
--- a/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerGridAdapter.java
+++ b/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerGridAdapter.java
@@ -1,0 +1,28 @@
+package co.paulburke.android.itemtouchhelperdemo;
+
+import android.content.Context;
+
+import co.paulburke.android.itemtouchhelperdemo.helper.OnStartDragListener;
+
+/**
+ * Date: 2016-03-17
+ * Time: 21:08
+ * Author: cf
+ * -----------------------------
+ */
+public class RecyclerGridAdapter extends RecyclerListAdapter {
+
+    public RecyclerGridAdapter(Context context, OnStartDragListener dragStartListener) {
+        super(context, dragStartListener);
+    }
+
+    @Override
+    public boolean onItemMove(int fromPosition, int toPosition) {
+        String str = mItems.get(fromPosition);
+        mItems.remove(fromPosition);
+        mItems.add(toPosition, str);
+
+        notifyItemMoved(fromPosition, toPosition);
+        return true;
+    }
+}

--- a/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerGridFragment.java
+++ b/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerGridFragment.java
@@ -49,7 +49,7 @@ public class RecyclerGridFragment extends Fragment implements OnStartDragListene
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final RecyclerListAdapter adapter = new RecyclerListAdapter(getActivity(), this);
+        final RecyclerGridAdapter adapter = new RecyclerGridAdapter(getActivity(), this);
 
         RecyclerView recyclerView = (RecyclerView) view;
         recyclerView.setHasFixedSize(true);

--- a/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerListAdapter.java
+++ b/app/src/main/java/co/paulburke/android/itemtouchhelperdemo/RecyclerListAdapter.java
@@ -45,7 +45,7 @@ import co.paulburke.android.itemtouchhelperdemo.helper.OnStartDragListener;
 public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapter.ItemViewHolder>
         implements ItemTouchHelperAdapter {
 
-    private final List<String> mItems = new ArrayList<>();
+    protected final List<String> mItems = new ArrayList<>();
 
     private final OnStartDragListener mDragStartListener;
 


### PR DESCRIPTION
When I moved the 'Four' item over the 'One' item,the views were not swaped as expected,instead,the 'Four' item was inserted before the 'One' item.
